### PR TITLE
fix: quote YAML descriptions to fix skill discovery

### DIFF
--- a/src/marketing/paw-mkt-cro/SKILL.md
+++ b/src/marketing/paw-mkt-cro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-mkt-cro
-description: Optimizes conversion across landing pages, signup flows, forms, popups, paywalls, and onboarding. Use when: 'CRO', 'conversion rate', 'landing page', 'signup flow', 'A/B test', 'form optimization', 'exit popup', or 'user activation'.
+description: "Optimizes conversion across landing pages, signup flows, forms, popups, paywalls, and onboarding. Use when: 'CRO', 'conversion rate', 'landing page', 'signup flow', 'A/B test', 'form optimization', 'exit popup', or 'user activation'."
 ---
 
 # CRO Specialist

--- a/src/marketing/paw-mkt-seo/SKILL.md
+++ b/src/marketing/paw-mkt-seo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-mkt-seo
-description: SEO specialist for technical audits, keyword strategy, local SEO, link building, pSEO, and GEO optimization. Triggers: 'SEO', 'keyword research', 'schema markup', 'crawlability', 'pSEO', 'GEO', 'search rankings', 'link building'.
+description: "SEO specialist for technical audits, keyword strategy, local SEO, link building, pSEO, and GEO optimization. Triggers: 'SEO', 'keyword research', 'schema markup', 'crawlability', 'pSEO', 'GEO', 'search rankings', 'link building'."
 ---
 
 # SEO Specialist

--- a/src/prodig/paw-ps-audience/SKILL.md
+++ b/src/prodig/paw-ps-audience/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-ps-audience
-description: Customer insight specialist for audience understanding. Use when defining target audience, buyer personas, customer pains, value mapping, problem discovery, audience language. Triggers: 'who would buy this', 'target audience', 'buyer persona', 'customer pain points', 'ideal customer', 'user problems', 'value proposition', 'audience research'.
+description: "Customer insight specialist for audience understanding. Use when defining target audience, buyer personas, customer pains, value mapping, problem discovery, audience language. Triggers: 'who would buy this', 'target audience', 'buyer persona', 'customer pain points', 'ideal customer', 'user problems', 'value proposition', 'audience research'."
 ---
 
 # Audience Intelligence Agent

--- a/src/prodig/paw-ps-discovery/SKILL.md
+++ b/src/prodig/paw-ps-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-ps-discovery
-description: Creative discovery partner for ideation and concept shaping. Use when brainstorming, exploring product ideas, expanding vague concepts, comparing directions, finding opportunities, creative ideation. Triggers: 'brainstorm', 'product ideas', 'concept exploration', 'idea expansion', 'creative thinking', 'product discovery', 'what if', 'I have an idea'.
+description: "Creative discovery partner for ideation and concept shaping. Use when brainstorming, exploring product ideas, expanding vague concepts, comparing directions, finding opportunities, creative ideation. Triggers: 'brainstorm', 'product ideas', 'concept exploration', 'idea expansion', 'creative thinking', 'product discovery', 'what if', 'I have an idea'."
 ---
 
 # Discovery Agent

--- a/src/prodig/paw-ps-orchestrator/SKILL.md
+++ b/src/prodig/paw-ps-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-ps-orchestrator
-description: Strategic product commander for Prodig Suites. Use when building digital products, product planning, product creation, idea validation, market research routing, product strategy. Triggers: 'prodig', 'product suite', 'digital product', 'product idea', 'course creation', 'SaaS planning', 'template pack', 'productized service'.
+description: "Strategic product commander for Prodig Suites. Use when building digital products, product planning, product creation, idea validation, market research routing, product strategy. Triggers: 'prodig', 'product suite', 'digital product', 'product idea', 'course creation', 'SaaS planning', 'template pack', 'productized service'."
 ---
 
 # Prodig Orchestrator

--- a/src/prodig/paw-ps-research/SKILL.md
+++ b/src/prodig/paw-ps-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-ps-research
-description: Rigorous market researcher for Prodig Suites. Use for competitor analysis, demand signal analysis, gap identification, market intelligence. Triggers: 'market research', 'competitor analysis', 'demand validation', 'market gaps', 'opportunity research', 'competitive landscape'.
+description: "Rigorous market researcher for Prodig Suites. Use for competitor analysis, demand signal analysis, gap identification, market intelligence. Triggers: 'market research', 'competitor analysis', 'demand validation', 'market gaps', 'opportunity research', 'competitive landscape'."
 ---
 
 # Research Agent

--- a/src/prodig/paw-ps-service-executor/SKILL.md
+++ b/src/prodig/paw-ps-service-executor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-ps-service-executor
-description: Builder of productized services, consulting packages, and agency offers. Use when creating service packages, consulting offerings, done-for-you services, agency service design, productized service, service delivery framework. Triggers: 'productized service', 'consulting package', 'agency offer', 'service packaging', 'done-for-you', 'DFY', 'service product'.
+description: "Builder of productized services, consulting packages, and agency offers. Use when creating service packages, consulting offerings, done-for-you services, agency service design, productized service, service delivery framework. Triggers: 'productized service', 'consulting package', 'agency offer', 'service packaging', 'done-for-you', 'DFY', 'service product'."
 ---
 
 # Service Executor

--- a/src/webinar/paw-wbc-agent-producer/SKILL.md
+++ b/src/webinar/paw-wbc-agent-producer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paw-wbc-agent-producer
-description: Structured producer who turns research insights into production-ready slide deck outlines and scripts. Triggers: 'create slides', 'write webinar script', 'build slide deck', 'webinar outline', 'produce webinar', or when user asks for the Producer.
+description: "Structured producer who turns research insights into production-ready slide deck outlines and scripts. Triggers: 'create slides', 'write webinar script', 'build slide deck', 'webinar outline', 'produce webinar', or when user asks for the Producer."
 ---
 
 # Producer


### PR DESCRIPTION
## Summary

- Fixed invalid YAML frontmatter in 8 SKILL.md files by quoting description fields
- Skills CLI was silently failing to discover these skills due to unquoted colons in descriptions

## Problem

When running `npx skills add pawbytes/skill-suites --list`, 8 skills were missing from the discovery output:

**Prodig Suite (5 skills):**
- `paw-ps-orchestrator`
- `paw-ps-discovery`
- `paw-ps-audience`
- `paw-ps-research`
- `paw-ps-service-executor`

**Webinar Suite (1 skill):**
- `paw-wbc-agent-producer`

**Marketing Suite (2 skills):**
- `paw-mkt-cro`
- `paw-mkt-seo`

## Root Cause

The `description` field in YAML frontmatter contained unquoted colons (e.g., `Triggers:` and `Use when:`) that YAML interpreted as new keys, causing silent parse failures. The Vercel Skills CLI has a known bug (issue #452) where it skips recursive search when skills are found in standard directories - combined with YAML parse failures, these skills became invisible.

## Fix

Wrapped all description values in double quotes to properly escape the colons:

```yaml
# Before (invalid)
description: Some text. Triggers: 'keyword', 'another'.

# After (valid)
description: "Some text. Triggers: 'keyword', 'another'."
```

## Test plan

- [x] Ran `npx skills add . --list` locally - all 61 skills now discovered
- [x] Validated YAML frontmatter with Python yaml.safe_load - all files pass